### PR TITLE
Add third assignee (Muhammad Umer) to time entry sync

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
 substitutions:
   _CLICKUP_TOKEN: '55424762_44fc0fcb470696596dc4894e3aa4fd17a265af257f6048373acb9e1e877e7f8b'
   _TEAM_ID: '37496228'
-  _ASSIGNEES: '55424762,55427758'
+  _ASSIGNEES: '55424762,55427758,88552909'
   _PROJECT_ID: 'nettsmed-internal'
   _DATASET: 'clickup_data'
   _STAGING_TABLE: 'staging_time_entries'

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -44,7 +44,7 @@ docker run --env-file .env -p 8080:8080 clickup-bigquery-pipeline:latest
 docker run \
   -e CLICKUP_TOKEN=55424762_44fc0fcb470696596dc4894e3aa4fd17a265af257f6048373acb9e1e877e7f8b \
   -e TEAM_ID=37496228 \
-  -e ASSIGNEES=55424762,55427758 \
+  -e ASSIGNEES=55424762,55427758,88552909 \
   -e PROJECT_ID=nettsmed-internal \
   -e DATASET=clickup_data \
   -e STAGING_TABLE=staging_time_entries \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,7 +32,7 @@ pip install -r requirements.txt
 ```env
 CLICKUP_TOKEN=your_token_here
 TEAM_ID=37496228
-ASSIGNEES=55424762,55427758
+ASSIGNEES=55424762,55427758,88552909
 PROJECT_ID=nettsmed-internal
 DATASET=clickup_data
 STAGING_TABLE=staging_time_entries

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -41,7 +41,7 @@ The script will:
 ### Environment Variables (in Cloud Run)
 - `CLICKUP_TOKEN`: ClickUp API token
 - `TEAM_ID`: ClickUp team ID (37496228)
-- `ASSIGNEES`: Comma-separated user IDs (55424762,55427758)
+- `ASSIGNEES`: Comma-separated user IDs (55424762,55427758,88552909)
 - `PROJECT_ID`: GCP project ID (nettsmed-internal)
 - `DATASET`: BigQuery dataset (clickup_data)
 - `STAGING_TABLE`: BigQuery staging table (staging_time_entries)


### PR DESCRIPTION
## Summary
Adds Muhammad Umer (ID: 88552909) as the third assignee for time entry synchronization.

## Changes
- Updated `cloudbuild.yaml` with assignee ID 88552909
- Updated documentation:
  - `docs/DOCKER_SETUP.md`
  - `docs/setup.md`
  - `docs/reference.md`

## Testing
✅ Successfully tested locally with 7-day refresh sync
✅ Full backfill completed and verified in BigQuery

## Verification Results
**All-Time Data (Jan 2024 - Oct 2025):**
- Sindre Fjellestad (55424762): 599 entries
- Eirik B. Fjellestad (55427758): 979 entries
- Muhammad Umer (88552909): 373 entries ✅
- **Total: 1,951 entries**

**Last 30 Days:**
- 137 total entries across all three employees

## Deployment
After merging, redeploy using `./deploy.sh` to apply changes to Cloud Run.