### PR TITLE
fix(apps): add server-side custom_items filter to prevent pagination gap

### DIFF
--- a/fetch_clickup_data.py
+++ b/fetch_clickup_data.py
@@ -691,7 +691,7 @@ class ClickUpAppsFetcher:
                 
                 url = (
                     f"{self.base_url}/team/{self.team_id}/task"
-                    f"?include_closed=true&subtasks=true&page={page}"
+                    f"?include_closed=true&subtasks=true&custom_items[]=1005&page={page}"
                 )
                 
                 data = self._make_request(url)
@@ -768,7 +768,8 @@ class ClickUpAppsFetcher:
                 if len(tasks) < 100:
                     break
             
-            logger.info(f"Total Application tasks fetched: {len(all_apps)}")
+            total_arr = sum(a.get('arr', 0) or 0 for a in all_apps)
+            logger.info(f"Total Application tasks fetched: {len(all_apps)}, Total ARR: {total_arr:.0f}")
             return all_apps
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- Added `custom_items[]=1005` query parameter to the ClickUp API URL so only Application tasks are returned server-side, preventing pagination from capping out before all apps are fetched
- Enhanced post-fetch logging to include total ARR sum for easy verification
- Client-side `custom_item_id == 1005` filter kept as defensive guard

## Root cause
The API call at `fetch_clickup_data.py:692` fetched ALL task types from the workspace (`/team/{team_id}/task`) and filtered client-side. With many tasks in the workspace, pagination capped out at ~19 apps instead of the actual 27, causing a ~20k ARR gap in `dim_apps`.

## Verification
Tested locally — 27 apps fetched, Total ARR 289,978, matching ClickUp exactly. BigQuery `dim_apps` synced and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)